### PR TITLE
Fix README (this repo is a scam)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
 # CVE-2022-23529
 
-The JSON Web Token (JWT) library versions prior to 3.4.6, 4.0.4, and 4.1.5 are vulnerable to RCE.
+The JSON Web Token (JWT) library versions prior to 3.4.6, 4.0.4, and 4.1.5 are vulnerable to RCE if you already have RCE.
 
-The HMAC hashing functions take any string as input which leads to RCE.
+Due to the preconditions (RCE), this vulnerability does not make any sense.
 
-Due to the preconditions, this vulnerability is not likly to be exploitable.
-
-In order to exploit this vulnerability an attacker would need one of the following conditions to be true:
+In order to exploit this vulnerability an attacker would need all of the following conditions to be true:
 
 - The server does not store secret keys securely.
 - The attacker needs to have access to and control the secret keys.
-
+- The attacker can write and execute arbitrary code.
 
 
 ## npm install jsonwebtoken@8.5.1


### PR DESCRIPTION
I love how you removed the "GitHub Issues" section after I pointed out that this doesn't make any sense.

If you truly believe this is an actual vulnerability, then I suggest you try reporting the very same payload as an exploit for the build-in `btoa` or even the `+` operator! Basically you have a universal RCE in everything JavaScript! 🤡 (... or you know, the prerequisite make no sense, so the "vulnerability" is not actually a vulnerability)